### PR TITLE
Fix #7: Update content check to '!isNaN'

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ bot.on("message", (msg) => {
 						"*"
 				);
 			});
-		} else if (Number(content[0])) {
+		} else if (!isNaN(content[0])) {
 			let reply = roll.parse(content);
 
 			msg.reply(reply).catch((error) => {


### PR DESCRIPTION
This is a fix for rolling a zero (https://github.com/jordanclarkedev/bitdicebot/issues/7)